### PR TITLE
転送データ0件でも転送実行

### DIFF
--- a/embulk-input-google_adwords.gemspec
+++ b/embulk-input-google_adwords.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "embulk-input-google_adwords"
-  spec.version       = "0.1.3"
+  spec.version       = "0.1.4"
   spec.authors       = ["topdeveloper"]
   spec.summary       = "Google Adwords input plugin for Embulk"
   spec.description   = "Loads records from Google Adwords."

--- a/lib/embulk/input/google_adwords.rb
+++ b/lib/embulk/input/google_adwords.rb
@@ -86,6 +86,7 @@ module Embulk
         query << " DURING #{task["daterange"]["min"]},#{task["daterange"]["max"]}" unless task["daterange"].empty?
         begin
           query_report_results(query) do |row|
+            next if row.empty?
             page_builder.add formated_row(task["fields"], row, task["convert_column_type"], task["use_micro_yen"])
           end
 


### PR DESCRIPTION
# 概要
- 転送データ0件の時，途中でプラグインが落ちないようにする

# 実装
- query実行結果の各行(row)がemptyであれば処理を飛ばすようにした

# テスト
- ローカルにおいて，embulk previewではNo input records to preview，runでは0件で転送が行われた