### PR TITLE
Fix json data error

### DIFF
--- a/embulk-input-google_adwords.gemspec
+++ b/embulk-input-google_adwords.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name = "embulk-input-google_adwords"
-  spec.version = "0.1.9"
+  spec.version = "0.1.10"
   spec.authors = ["topdeveloper"]
   spec.summary = "Google Adwords input plugin for Embulk"
   spec.description = "Loads records from Google Adwords."

--- a/lib/embulk/input/google_adwords.rb
+++ b/lib/embulk/input/google_adwords.rb
@@ -1,4 +1,5 @@
 require "adwords_api"
+require "csv"
 
 module Embulk
   module Input
@@ -120,22 +121,11 @@ module Embulk
           end
           last_line = rows.delete_at(-1)
           rows.each do |row|
-            row.chomp!
-            json_data_array = row.scan(/\"\[{.+?}\]\"/)
-            data_array = row.gsub!(/\"\[{.+?}\]\"/, "json_data").split(",").map do |data|
-              if data == "json_data"
-                value = json_data_array.first
-                json_data_array.shift
-              else
-                value = data
-              end
-              value
-            end
-            block.call data_array
+            block.call CSV.parse(row.chomp!).first
           end
         end
 
-        block.call last_line.chomp.split(",")
+        block.call CSV.parse(last_line.chomp).first
       end
 
       def formated_row(fields, row, convert_column_type, use_micro_yen)

--- a/lib/embulk/input/google_adwords.rb
+++ b/lib/embulk/input/google_adwords.rb
@@ -121,7 +121,17 @@ module Embulk
           last_line = rows.delete_at(-1)
           rows.each do |row|
             row.chomp!
-            block.call row.split(",")
+            json_data_array = row.scan(/\"\[{.+?}\]\"/)
+            data_array = row.gsub!(/\"\[{.+?}\]\"/, "json_data").split(",").map do |data|
+              if data == "json_data"
+                value = json_data_array.first
+                json_data_array.shift
+              else
+                value = data
+              end
+              value
+            end
+            block.call data_array
           end
         end
 


### PR DESCRIPTION
# Detail
* When list of fields includes ResponsiveSearchAdHeadlines or ResponsiveSearchAdDescriptions, the error is raised.
* The reason is that the type of these data is json.