### PR TITLE
do not allocate buffer for rows

### DIFF
--- a/lib/embulk/input/google_adwords.rb
+++ b/lib/embulk/input/google_adwords.rb
@@ -115,7 +115,7 @@ module Embulk
       def query_report_results(query, &block)
         report_utils.download_report_as_stream_with_awql(query, "CSV") do |lines|
           lines.lines do |line|
-            block.call CSV.parse(line.chop!).first
+            block.call CSV.parse(line.chomp!).first
           end
         end
       end

--- a/lib/embulk/input/google_adwords.rb
+++ b/lib/embulk/input/google_adwords.rb
@@ -113,7 +113,6 @@ module Embulk
 
       def query_report_results(query, &block)
         report_utils.download_report_as_stream_with_awql(query, "CSV") do |lines|
-          return unless lines
           lines.lines do |line|
             block.call CSV.parse(line.chop!).first
           end

--- a/lib/embulk/input/google_adwords.rb
+++ b/lib/embulk/input/google_adwords.rb
@@ -112,20 +112,12 @@ module Embulk
       end
 
       def query_report_results(query, &block)
-        last_line = ""
-
         report_utils.download_report_as_stream_with_awql(query, "CSV") do |lines|
-          rows = []
-          (last_line + lines).lines do |line|
-            rows << line
-          end
-          last_line = rows.delete_at(-1)
-          rows.each do |row|
-            block.call CSV.parse(row.chomp!).first
+          return unless lines
+          lines.lines do |line|
+            block.call CSV.parse(line.chop!).first
           end
         end
-
-        block.call CSV.parse(last_line.chomp).first
       end
 
       def formated_row(fields, row, convert_column_type, use_micro_yen)

--- a/lib/embulk/input/google_adwords.rb
+++ b/lib/embulk/input/google_adwords.rb
@@ -91,6 +91,7 @@ module Embulk
         query_report_results(query) do |row|
           next if row.nil? || row.empty?
           page_builder.add formated_row(task["fields"], row, task["convert_column_type"], task["use_micro_yen"])
+          page_builder.flush
         end
 
         page_builder.finish


### PR DESCRIPTION
We can simplify this logic, which has a low memory usage benefit